### PR TITLE
Port to CE3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,13 @@ project/target
 project/project/*
 !project/project/plugins.sbt
 
+# Metals + Bloop
+.metals/
+metals.sbt
+.bloop/
+.bsp/
+.vscode/
+
 # IDEA specific
 .idea
 

--- a/build.sbt
+++ b/build.sbt
@@ -139,25 +139,15 @@ lazy val root = project
   .settings(
     name := "log-effect",
     publishArtifact := false,
-    addCommandAlias("fmt", ";scalafmt;test:scalafmt;scalafmtSbt"),
-    addCommandAlias(
-      "checkFormat",
-      ";scalafmtCheck;test:scalafmtCheck;scalafmtSbtCheck"
-    ),
-    addCommandAlias(
-      "ciBuild",
-      ";clean;test"
-    ),
-    addCommandAlias(
-      "fullBuild",
-      ";checkFormat;ciBuild"
-    ),
-    // travis release aliases
+    addCommandAlias("fmt", "scalafmt;Test/scalafmt;scalafmtSbt"),
+    addCommandAlias("checkFormat", "scalafmtCheck;Test/scalafmtCheck;scalafmtSbtCheck"),
+    addCommandAlias("ciBuild", "clean;test"),
+    addCommandAlias("fullBuild", "checkFormat;ciBuild"),
     addCommandAlias(
       "setReleaseOptions",
       "set scalacOptions ++= Seq(\"-opt:l:method\", \"-opt:l:inline\", \"-opt-inline-from:laserdisc.**\", \"-opt-inline-from:<sources>\")"
     ),
-    addCommandAlias("releaseIt", ";clean;setReleaseOptions;session list;compile;ci-release")
+    addCommandAlias("releaseIt", "clean;setReleaseOptions;session list;compile;ci-release")
   )
 
 lazy val core = project

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ lazy val scala_213 = "2.13.5"
 
 lazy val versionOf = new {
   val cats          = "2.6.0"
-  val catsEffect    = "2.5.0"
-  val fs2           = "2.5.5"
+  val catsEffect    = "3.1.0"
+  val fs2           = "3.0.2"
   val kindProjector = "0.11.3"
-  val log4cats      = "1.3.0"
+  val log4cats      = "2.1.0"
   val log4s         = "1.9.0"
   val scalaCheck    = "1.15.4"
   val scalaTest     = "3.2.8"

--- a/fs2/src/test/scala/log/effect/fs2/TestLogCapture.scala
+++ b/fs2/src/test/scala/log/effect/fs2/TestLogCapture.scala
@@ -4,6 +4,7 @@ package fs2
 import java.io.{ByteArrayOutputStream, PrintStream}
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 
 trait TestLogCapture {
 

--- a/interop/src/test/scala/InteropTest.scala
+++ b/interop/src/test/scala/InteropTest.scala
@@ -8,7 +8,7 @@ final class InteropTest extends AnyWordSpecLike with Matchers with TestLogCaptur
 
   "A LogWriter instance can be derived from a log4cats Logger" in {
     import cats.effect.IO
-    import cats.syntax.flatMap._
+    import cats.effect.unsafe.implicits.global
     import org.typelevel.log4cats.slf4j.Slf4jLogger
     import log.effect.LogWriter
     import log.effect.internal.Show
@@ -21,7 +21,7 @@ final class InteropTest extends AnyWordSpecLike with Matchers with TestLogCaptur
         }
     }
 
-    val logged = capturedLog4sOutOf[IO] { logger =>
+    val logged = capturedLog4sOutOf { logger =>
       import log.effect.interop.log4cats._
 
       implicit val buildMessageLogger =

--- a/interop/src/test/scala/log/effect/interop/TestLogCapture.scala
+++ b/interop/src/test/scala/log/effect/interop/TestLogCapture.scala
@@ -1,24 +1,23 @@
 package log.effect
 package interop
 
-import cats.effect.{Effect, Sync}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.syntax.flatMap._
 import org.log4s.{LoggedEvent, TestAppender, getLogger}
 import org.slf4j.Logger
 
 trait TestLogCapture {
 
-  protected final def capturedLog4sOutOf[F[_]: Effect](
-    logWrite: Logger => F[Unit]
+  protected final def capturedLog4sOutOf(
+    logWrite: Logger => IO[Unit]
   ): Seq[LoggedEvent] = {
-    val loggingAction: F[Unit] =
-      Sync[F].delay(getLogger("Test Logger").logger) >>= { logger =>
-        TestAppender.withAppender() {
-          logWrite(logger)
-        }
+    val loggingAction = IO.delay(getLogger("Test Logger").logger) >>= { logger =>
+      TestAppender.withAppender() {
+        logWrite(logger)
       }
-
-    Effect[F].toIO(loggingAction).unsafeRunSync()
+    }
+    loggingAction.unsafeRunSync()
 
     TestAppender.dequeueAll()
   }


### PR DESCRIPTION
A few things to consider:
1. the context bound `: Async` on the readme samples for RedisClient may need to be reviewed once we port laserdisc to CE3 and see what options we have
2. there may be nicer ways to do unsafeRunSync in the tests, including importing cats-effect-testkit but I thought this was the most straightforward